### PR TITLE
Convert both owner and sender to lowercase before matching.

### DIFF
--- a/src/subdomains.ts
+++ b/src/subdomains.ts
@@ -200,7 +200,7 @@ export default class extends Composer implements Subdomains {
 
     if (!addr) {
       return this._setSubnodeOwner(node, label, owner || sender, options);
-    } if (!owner || owner === sender) {
+    } if (!owner || owner.toLowerCase() === sender.toLowerCase()) {
       // submits just two transactions
       await this._setSubnodeOwner(node, label, sender, options);
 


### PR DESCRIPTION
When calling the following statement:

```
rns.subdomains.create(parentDomain, subdomain, owner, owner)
```

whereas owner (lowercase) is the same as sender (checksummed)

It will always result in 3 transactions because newOwner is being checked against the sender address from the wallet which is checksummed.

Found the issue in Nifty, but since Metamask returns addresses checksummed to eth, this is probably an issue there too. 

Closes #107.