### PR TITLE
feat: impl rns.resolver(name) - getter function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,20 @@ export default class extends Composer implements RNS {
   }
 
   /**
+   * Get decoded contenthash of a given domain.
+   *
+   * @throws DOMAIN_NOT_EXISTS if the given domain does not exists - KB012
+   * @throws NO_RESOLVER when the domain doesn't have resolver - KB003
+   *
+   * @param domain - Domain to be resolved
+   *
+   * @returns Address of the resolver associated with the given domain
+   */
+  resolver(domain: string): Promise<string> {
+    return this._resolutions.resolver(domain);
+  }
+
+  /**
    * Set resolver of a given domain.
    *
    * @throws NO_ACCOUNTS_TO_SIGN if the given blockchain api instance does not have associated accounts to sign the transaction - KB015

--- a/src/resolutions.ts
+++ b/src/resolutions.ts
@@ -301,6 +301,25 @@ export default class extends Composer implements Resolutions {
     return this.estimateGasAndSendTransaction(contractMethod, options);
   }
 
+  async resolver(domain: string): Promise<string> {
+    await this.compose();
+    const node: string = namehash(domain);
+
+    const domainOwner = await
+    this._contracts.registry.methods.owner(node).call();
+    if (domainOwner === ZERO_ADDRESS) {
+      this._throw(DOMAIN_NOT_EXISTS);
+    }
+
+    const resolverAddress: string = await
+    this._contracts.registry.methods.resolver(node).call();
+    if (resolverAddress === ZERO_ADDRESS) {
+      this._throw(NO_RESOLVER);
+    }
+
+    return resolverAddress;
+  }
+
   async setResolver(
     domain: string, resolver: string, options?: TransactionOptions,
   ): Promise<string> {

--- a/src/types/resolutions.ts
+++ b/src/types/resolutions.ts
@@ -66,6 +66,13 @@ export interface Resolutions {
   setContenthash(domain: string, content: string, options?: TransactionOptions): any;
 
   /**
+   * Get resolver of a given domain.
+   *
+   * @param domain - Domain to be resolved
+   */
+  resolver(domain: string): Promise<string>;
+
+  /**
    * Set resolver of a given domain.
    *
    * @param domain - Domain to set resolver


### PR DESCRIPTION
## What

- impl `rns.resolver(name)` getter function

## Why

- there is a setter function (`rns.setResolver(name, address)`), but no corresponding getter function

## Refs

- Issues: [#121](https://github.com/rnsdomains/rns-js/issues/121)